### PR TITLE
Add Publisher endpoints

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -1,0 +1,64 @@
+defmodule ExIsbndb.Publisher do
+  @moduledoc """
+  The `ExIsbndb.Publisher` module contains all the available endpoints for Publishers.
+
+  All functions need to receive a map with params, but only those
+  needed for the endpoint will be taken.
+  """
+
+  alias ExIsbndb.Client
+
+  @doc """
+  Returns the Publisher's details and a list of published Books.
+
+  Params required:
+
+  * name (string) - name of the Publisher
+
+  Params available:
+
+  * page (integer) - page number of the Books to be retrieved
+  * page_size(integer) - number of Books to be retrieved per page
+
+  Any other parameters will be ignored.
+
+  ## Examples
+
+      iex> ExIsbndb.Publisher.get(%{name: "Pearson", page: 1, page_size: 5})
+      {:ok, %Finch.Response{body: "...", headers: [...], status: 200}}
+
+  """
+  @spec get(map()) :: {:ok, Finch.Response.t()} | {:error, Exception.t()}
+  def get(%{name: name} = params) when is_binary(name) do
+    params = %{page: params[:page], pageSize: params[:page_size]}
+
+    Client.request(:get, "publisher/#{URI.encode(name)}", params)
+  end
+
+  @doc """
+  Returns all the Publishers that match the given query.
+
+  Params required:
+
+  * query (string) - string used to search
+
+  Params available:
+
+  * page (integer) - page number of the Publishers to be searched
+  * page_size (integer) - number of Publishers to be searched per page
+
+  Any other parameters will be ignored.
+
+  ## Examples
+
+      iex> ExIsbndb.Publisher.search(%{query: "oxford", page: 1, page_size: 5})
+      {:ok, %Finch.Response{body: "...", headers: [...], status: 200}}
+
+  """
+  @spec search(map()) :: {:ok, Finch.Response.t()} | {:error, Exception.t()}
+  def search(%{query: query} = params) when is_binary(query) do
+    params = %{page: params[:page], pageSize: params[:page_size]}
+
+    Client.request(:get, "publishers/#{URI.encode(query)}", params)
+  end
+end

--- a/test/publisher_test.exs
+++ b/test/publisher_test.exs
@@ -1,0 +1,53 @@
+defmodule ExIsbndb.PublisherTest do
+  use ExUnit.Case
+  import Mock
+  alias ExIsbndb.Publisher
+
+  describe "get/1" do
+    @valid_params %{name: "Bloomsbury", page: 1, page_size: 10}
+    @not_name_params %{page: 1, page_size: 10}
+    @not_binary_name_params %{name: :name, page: 1, page_size: 10}
+
+    test "Returns a response when the params are valid" do
+      with_mock(Finch, [:passthrough],
+        request: fn _request, _server ->
+          {:ok, %Finch.Response{body: "Publisher...", headers: [], status: 200}}
+        end
+      ) do
+        assert {:ok, %Finch.Response{}} = Publisher.get(@valid_params)
+      end
+    end
+
+    test "Raises an error if name not provided" do
+      assert_raise FunctionClauseError, fn -> Publisher.get(@not_name_params) end
+    end
+
+    test "Raises an error if name is not a binary" do
+      assert_raise FunctionClauseError, fn -> Publisher.get(@not_binary_name_params) end
+    end
+  end
+
+  describe "search/1" do
+    @valid_params %{query: "oxford", page: 1, page_size: 10}
+    @not_query_params %{page: 1, page_size: 10}
+    @not_binary_query_params %{query: :query, page: 1, page_size: 10}
+
+    test "Returns a response when the params are valid" do
+      with_mock(Finch, [:passthrough],
+        request: fn _request, _server ->
+          {:ok, %Finch.Response{body: "Publisher...", headers: [], status: 200}}
+        end
+      ) do
+        assert {:ok, %Finch.Response{}} = Publisher.search(@valid_params)
+      end
+    end
+
+    test "Raises an error if query not provided" do
+      assert_raise FunctionClauseError, fn -> Publisher.search(@not_query_params) end
+    end
+
+    test "Raises an error if query is not a binary" do
+      assert_raise FunctionClauseError, fn -> Publisher.search(@not_binary_query_params) end
+    end
+  end
+end


### PR DESCRIPTION
Endpoints added for the Publisher scope:

* `get/1` - retrieves the details and books for an specific publisher
* `search/1` - returns all the available publishers that matches the query

Also added tests for both.