### PR TITLE
Add Stats endpoints

### DIFF
--- a/lib/stats.ex
+++ b/lib/stats.ex
@@ -1,0 +1,29 @@
+defmodule ExIsbndb.Stats do
+  @moduledoc """
+  The `ExIsbndb.Stats` module contains all endpoints related to the
+  stats of the ISBNdb database.
+  """
+
+  alias ExIsbndb.Client
+
+  @doc """
+  Returns the stats information about the ISBNdb database.
+
+  The response contains:
+
+  * number of books in the database
+  * number of authors in the database
+  * number of publishers in the database
+
+  This is a good endpoint to test if the API works, as it doesn't need
+  any parameter to work.
+
+  ## Examples
+
+      iex> ExIsbndb.Stats.stats()
+      {:ok, %Finch.Response{body: "...", headers: [...], status: 200}}
+
+  """
+  @spec stats() :: {:ok, Finch.Response.t()} | {:error, Exception.t()}
+  def stats, do: Client.request(:get, "stats/")
+end

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -1,0 +1,17 @@
+defmodule ExIsbndb.StatsTest do
+  use ExUnit.Case
+  import Mock
+  alias ExIsbndb.Stats
+
+  describe "stats/1" do
+    test "Returns a response" do
+      with_mock(Finch, [:passthrough],
+        request: fn _request, _server ->
+          {:ok, %Finch.Response{body: "Stats...", headers: [], status: 200}}
+        end
+      ) do
+        assert {:ok, %Finch.Response{}} = Stats.stats()
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `stats/0` function will call the `/stats` endpoint, which will return the count of books, authors and publishers stored in the ISBNdb database.
It's also a good endpoint to test if the API works, as it does not need any param to work.