### PR TITLE
Add Subject endpoints

### DIFF
--- a/lib/subject.ex
+++ b/lib/subject.ex
@@ -1,0 +1,50 @@
+defmodule ExIsbndb.Subject do
+  @moduledoc """
+  The `ExIsbndb.Subject` module contains all the available endpoints for Subjects.
+  """
+
+  alias ExIsbndb.Client
+
+  @doc """
+  Returns details of a Subject and a list of Books that belong to it.
+
+  Params required:
+
+  * name (string) - name of the Subject
+
+  ## Examples
+
+      iex> ExIsbndb.Subject.get("drama")
+      {:ok, %Finch.Response{body: "...", headers: [...], status: 200}}
+
+  """
+  @spec get(binary()) :: {:ok, Finch.Response.t()} | {:error, Exception.t()}
+  def get(name) when is_binary(name), do: Client.request(:get, "subject/#{URI.encode(name)}")
+
+  @doc """
+  Returns all the Subjects that match the given query.
+
+  Params required:
+
+  * query (string) - string used to search
+
+  Params available:
+
+  * page (integer) - page number of the Subjects to be searched
+  * page_size (integer) - number of Subjects to be searched per page
+
+  Any other parameters will be ignored.
+
+  ## Examples
+
+      iex> ExIsbndb.Subject.search(%{query: "epic", page: 1, page_size: 5})
+      {:ok, %Finch.Response{body: "...", headers: [...], status: 200}}
+
+  """
+  @spec search(map()) :: {:ok, Finch.Response.t()} | {:error, Exception.t()}
+  def search(%{query: query} = params) when is_binary(query) do
+    params = %{page: params[:page], pageSize: params[:page_size]}
+
+    Client.request(:get, "subjects/#{URI.encode(query)}", params)
+  end
+end

--- a/test/subject_test.exs
+++ b/test/subject_test.exs
@@ -1,0 +1,48 @@
+defmodule ExIsbndb.SubjectTest do
+  use ExUnit.Case
+  import Mock
+  alias ExIsbndb.Subject
+
+  describe "get/1" do
+    @valid_name "drama"
+    @not_binary_name :drama
+
+    test "Returns a response when the name is valid" do
+      with_mock(Finch, [:passthrough],
+        request: fn _request, _server ->
+          {:ok, %Finch.Response{body: "Subject...", headers: [], status: 200}}
+        end
+      ) do
+        assert {:ok, %Finch.Response{}} = Subject.get(@valid_name)
+      end
+    end
+
+    test "Raises an error if the name is not a binary" do
+      assert_raise FunctionClauseError, fn -> Subject.get(@not_binary_name) end
+    end
+  end
+
+  describe "search/1" do
+    @valid_params %{query: "epic", page: 1, page_size: 10}
+    @not_query_params %{page: 1, page_size: 10}
+    @not_binary_query_params %{query: :query, page: 1, page_size: 10}
+
+    test "Returns a response when the params are valid" do
+      with_mock(Finch, [:passthrough],
+        request: fn _request, _server ->
+          {:ok, %Finch.Response{body: "Subject...", headers: [], status: 200}}
+        end
+      ) do
+        assert {:ok, %Finch.Response{}} = Subject.search(@valid_params)
+      end
+    end
+
+    test "Raises an error if query not provided" do
+      assert_raise FunctionClauseError, fn -> Subject.search(@not_query_params) end
+    end
+
+    test "Raises an error if query is not a binary" do
+      assert_raise FunctionClauseError, fn -> Subject.search(@not_binary_query_params) end
+    end
+  end
+end


### PR DESCRIPTION
The Subject endpoints return info about the Books' subjects as well as the Books belonging to them.

Added functions:

* `get/1` - returns details about a subject and Books belonging to it
* `search/1` - returns a list of Subjects matching the given query (can be paginated)