### PR TITLE
Fix Coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ExIsbndb [![.github/workflows/elixir_workflow.yaml](https://github.com/southgard/ex_isbndb/actions/workflows/elixir_workflow.yaml/badge.svg)](https://github.com/southgard/ex_isbndb/actions/workflows/elixir_workflow.yaml) [![Coverage Status](https://coveralls.io/repos/github/southgard/ex_isbndb/badge.svg?branch=feature/coverage-badges)](https://coveralls.io/github/southgard/ex_isbndb?branch=feature/coverage-badges)
+# ExIsbndb 
+
+[![.github/workflows/elixir_workflow.yaml](https://github.com/southgard/ex_isbndb/actions/workflows/elixir_workflow.yaml/badge.svg)](https://github.com/southgard/ex_isbndb/actions/workflows/elixir_workflow.yaml) [![Coverage Status](https://coveralls.io/repos/github/southgard/ex_isbndb/badge.svg?branch=main)](https://coveralls.io/github/southgard/ex_isbndb?branch=main)
 
 **TODO: Add description**
 


### PR DESCRIPTION
The coveralls badge was pointing to a branch so we were getting the % for that one.

Now we should be pointing correctly to main.